### PR TITLE
Support lists when merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "composer"
-version = "2.0.53"
+version = "2.0.58"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "composer"
-version = "2.0.58"
+version = "2.0.59"
 edition = "2021"
 authors = ["Sam Ruff - sam@bytesquid.com", "Ryan Brogden - ryan@bytesquid.com"]
 readme = "README.md"


### PR DESCRIPTION
This update ensures that when merging yaml files, lists with the same key name will merge together.