### PR TITLE
feat: build and publish a Debian package on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,3 +245,48 @@ jobs:
         with:
           file: "composer-${{ env.RELEASE_VERSION }}-1.x86_64.rpm"
           update_latest_release: true
+
+  create-deb:
+    needs: release
+    runs-on: ubuntu-latest
+    if: ((github.ref == 'refs/heads/master')) && (!contains(github.event.head_commit.message, 'chore:'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Download Version File
+        uses: actions/download-artifact@v4
+        with:
+          name: version
+
+      - name: Read Version File
+        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+
+      - name: Overwrite version in Cargo.toml
+        run: |
+          sed -i.bak -e 's/^version = "0\.0\.0"/version = "${{ env.RELEASE_VERSION }}"/' Cargo.toml && rm -f Cargo.toml.bak
+
+      - name: Build deb package
+        run: cargo deb
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: composer_deb
+          path: target/debian/*.deb
+
+      - name: Upload latest to latest release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: "target/debian/composer_${{ env.RELEASE_VERSION }}-1_amd64.deb"
+          update_latest_release: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,21 @@ name = "composer"
 version = "0.0.0"
 edition = "2021"
 authors = ["Sam Ruff - sam@bytesquid.com", "Ryan Brogden - ryan@bytesquid.com"]
+description = "A docker-compose package manager."
+license = "MIT"
+repository = "https://github.com/sam-ruff/composer-rust"
 readme = "README.md"
 resolver = "2"
+
+[package.metadata.deb]
+maintainer = "Sam Ruff <sam@bytesquid.com>"
+copyright = "Sam Ruff <sam@bytesquid.com>"
+extended-description = "Composer is a package manager for docker-compose applications. It installs, upgrades, templates and deletes compose applications defined with jinja2 templates and values files."
+section = "utils"
+priority = "optional"
+depends = "$auto"
+recommends = "docker-compose-v2 | docker-compose-plugin"
+assets = [["target/release/composer", "usr/bin/", "755"]]
 
 [profile.release]
 # Link time optimisations https://doc.rust-lang.org/cargo/reference/profiles.html#lto


### PR DESCRIPTION
Closes #12

## Change
- `Cargo.toml` gains `description`, `license = "MIT"` (matching the RPM spec) and `repository` package fields, plus a `[package.metadata.deb]` section: maintainer, extended description, `Depends: $auto` (resolves shared lib deps), and `Recommends: docker-compose-v2 | docker-compose-plugin`. The recommends rather than depends choice avoids blocking installs on machines that get Docker from Docker's own apt repo.
- New `create-deb` job in the release workflow, mirroring `create-rpm`: gated to master pushes, downloads the version artifact, substitutes the version into Cargo.toml the same way the build matrix does, runs `cargo deb`, and uploads `composer_<version>-1_amd64.deb` to the GitHub release. Uses `dtolnay/rust-toolchain` (same as the test job) rather than the deprecated `actions-rs` action.

## Verification
Built locally with the version substituted to `9.9.9` exactly as CI will do:

```
Package: composer
Version: 9.9.9-1
Architecture: amd64
Depends: libc6 (>= 2.39)
Recommends: docker-compose-v2 | docker-compose-plugin
```

`dpkg-deb --contents` shows `/usr/bin/composer` (755) plus the generated copyright file, and the extracted binary runs: `composer 9.9.9`. The output filename matches the upload step's pattern. Full test suite and clippy still clean.

Note: the repo has no LICENSE file even though the RPM spec already declares MIT; the deb copyright file is generated from the new `license` field. Adding a LICENSE file would be a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)