### PR TITLE
feat: add self-update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -89,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +111,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -216,11 +234,13 @@ dependencies = [
  "random-string",
  "regex",
  "relative-path",
+ "self-replace",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "serial_test",
  "tempfile",
+ "ureq",
  "walkdir",
 ]
 
@@ -237,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -257,7 +286,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -279,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -308,6 +337,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -427,6 +466,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,7 +540,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -582,6 +637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mockall"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +731,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -852,6 +923,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +946,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -890,6 +1010,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand 2.4.1",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "semver"
@@ -985,6 +1116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1138,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1042,7 +1185,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1088,6 +1231,47 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -1209,12 +1393,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1278,12 +1471,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1378,6 +1644,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ dirs = "6.0.0"
 serde_json = "1.0.150"
 chrono = "0.4.45"
 chrono-humanize = "0.2.3"
+ureq = "3.3.0"
+self-replace = "1.5.0"
+tempfile = "3.27"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -1,6 +1,7 @@
 use crate::commands::delete::Delete;
 use crate::commands::install::Install;
 use crate::commands::list::List;
+use crate::commands::self_update::SelfUpdate;
 use crate::commands::template::Template;
 use crate::commands::test::Test;
 use crate::commands::upgrade::Upgrade;
@@ -43,6 +44,8 @@ pub enum Cmd {
     ///   completely.
     #[clap(alias = "d", alias = "uninstall")]
     Delete(Delete),
+    /// Updates composer itself to the latest released version
+    SelfUpdate(SelfUpdate),
     // Hidden test function
     Test(Test),
 }
@@ -56,6 +59,7 @@ impl Cli {
             Cmd::Test(test) => test.exec()?,
             Cmd::Template(template) => template.exec()?,
             Cmd::Delete(delete) => delete.exec()?,
+            Cmd::SelfUpdate(self_update) => self_update.exec()?,
         }
         Ok(())
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod cli;
 mod delete;
 mod install;
 mod list;
+mod self_update;
 mod template;
 mod test;
 mod upgrade;

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -1,0 +1,53 @@
+use crate::utils::self_updater::{
+    current_asset_target, releases_page, run_self_update, GithubReleaseApi, SelfReplaceInstaller,
+    SelfUpdateOutcome,
+};
+use anyhow::{anyhow, Context};
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct SelfUpdate {
+    /// Only check whether a newer release exists, without installing it
+    #[clap(long)]
+    pub check: bool,
+}
+
+impl SelfUpdate {
+    pub fn exec(&self) -> anyhow::Result<()> {
+        let current_version = env!("CARGO_PKG_VERSION");
+        let target = current_asset_target().ok_or_else(|| {
+            anyhow!(
+                "Self-update is not supported on this platform. Download a release manually from {}",
+                releases_page()
+            )
+        })?;
+        let staging_dir = tempfile::tempdir().context("Failed to create a staging directory")?;
+        let staging_path = staging_dir.path().join("composer-update");
+
+        let api = GithubReleaseApi::new();
+        let installer = SelfReplaceInstaller;
+        let outcome = run_self_update(
+            &api,
+            &installer,
+            current_version,
+            target,
+            &staging_path,
+            self.check,
+        )?;
+        match outcome {
+            SelfUpdateOutcome::UpToDate { current } => {
+                info!("composer {} is already the latest version.", current);
+            }
+            SelfUpdateOutcome::UpdateAvailable { current, latest } => {
+                info!(
+                    "A newer composer release is available: {} (currently {}). Run 'composer self-update' to install it.",
+                    latest, current
+                );
+            }
+            SelfUpdateOutcome::Updated { from, to } => {
+                info!("Updated composer {} -> {}.", from, to);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod copy_file_utils;
 pub mod docker_compose;
 pub mod load_values;
+pub mod self_updater;
 pub mod storage;
 pub mod template;
 #[cfg(test)]

--- a/src/utils/self_updater.rs
+++ b/src/utils/self_updater.rs
@@ -1,0 +1,548 @@
+use anyhow::{anyhow, Context};
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+const RELEASES_URL: &str = "https://github.com/sam-ruff/composer-rust/releases";
+const LATEST_RELEASE_API_URL: &str =
+    "https://api.github.com/repos/sam-ruff/composer-rust/releases/latest";
+
+/// A published composer release.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReleaseInfo {
+    pub version: String,
+    pub assets: Vec<ReleaseAsset>,
+}
+
+/// A downloadable file attached to a release.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReleaseAsset {
+    pub name: String,
+    pub download_url: String,
+}
+
+/// Fetches release metadata and downloads release assets.
+#[cfg_attr(test, mockall::automock)]
+pub trait ReleaseApi {
+    fn latest_release(&self) -> anyhow::Result<ReleaseInfo>;
+    fn download(&self, url: &str, dest: &Path) -> anyhow::Result<()>;
+}
+
+/// Swaps the currently running executable for a staged replacement.
+#[cfg_attr(test, mockall::automock)]
+pub trait BinaryInstaller {
+    fn install(&self, staged: &Path) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SelfUpdateOutcome {
+    UpToDate { current: String },
+    UpdateAvailable { current: String, latest: String },
+    Updated { from: String, to: String },
+}
+
+/// Decides whether an update is needed and drives the download and install.
+/// Pure orchestration over the injected API and installer so it can be unit
+/// tested with the network mocked.
+pub fn run_self_update(
+    api: &dyn ReleaseApi,
+    installer: &dyn BinaryInstaller,
+    current_version: &str,
+    asset_target: &str,
+    staging_path: &Path,
+    check_only: bool,
+) -> anyhow::Result<SelfUpdateOutcome> {
+    let release = api
+        .latest_release()
+        .context("Failed to fetch the latest release")?;
+    let current = parse_version(current_version)
+        .ok_or_else(|| anyhow!("Could not parse the current version '{}'", current_version))?;
+    let latest = parse_version(&release.version).ok_or_else(|| {
+        anyhow!(
+            "Could not parse the latest release version '{}'",
+            release.version
+        )
+    })?;
+
+    if latest <= current {
+        return Ok(SelfUpdateOutcome::UpToDate {
+            current: current_version.to_string(),
+        });
+    }
+    if check_only {
+        return Ok(SelfUpdateOutcome::UpdateAvailable {
+            current: current_version.to_string(),
+            latest: release.version,
+        });
+    }
+    let asset = select_asset(&release.assets, asset_target).ok_or_else(|| {
+        anyhow!(
+            "Release {} has no binary for this platform (no asset matching '{}'). Download manually from {}",
+            release.version,
+            asset_target,
+            RELEASES_URL
+        )
+    })?;
+    api.download(&asset.download_url, staging_path)
+        .with_context(|| format!("Failed to download '{}'", asset.name))?;
+    installer
+        .install(staging_path)
+        .context("Failed to replace the current composer binary")?;
+    Ok(SelfUpdateOutcome::Updated {
+        from: current_version.to_string(),
+        to: release.version,
+    })
+}
+
+/// Parses an `x.y.z` version, tolerating a leading 'v'.
+fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
+    let version = version.trim().trim_start_matches('v');
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// Picks the raw binary asset for the given target triple, ignoring packaged
+/// artefacts such as the RPM and deb.
+fn select_asset<'a>(assets: &'a [ReleaseAsset], target: &str) -> Option<&'a ReleaseAsset> {
+    assets.iter().find(|asset| {
+        asset.name.contains(target)
+            && !asset.name.ends_with(".rpm")
+            && !asset.name.ends_with(".deb")
+    })
+}
+
+/// The asset target triple for the running platform, mirroring the targets
+/// produced by the release build matrix.
+pub fn current_asset_target() -> Option<&'static str> {
+    if cfg!(all(target_os = "linux", target_arch = "x86_64", target_env = "musl")) {
+        Some("x86_64-unknown-linux-musl")
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Some("x86_64-unknown-linux-gnu")
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        Some("x86_64-apple-darwin")
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        Some("x86_64-pc-windows-msvc")
+    } else {
+        None
+    }
+}
+
+/// Manual-download URL shown when self-update cannot run on this platform.
+pub fn releases_page() -> &'static str {
+    RELEASES_URL
+}
+
+/// Real implementation backed by the GitHub releases API.
+pub struct GithubReleaseApi {
+    latest_release_url: String,
+}
+
+impl GithubReleaseApi {
+    pub fn new() -> Self {
+        Self {
+            latest_release_url: LATEST_RELEASE_API_URL.to_string(),
+        }
+    }
+}
+
+impl Default for GithubReleaseApi {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReleaseApi for GithubReleaseApi {
+    fn latest_release(&self) -> anyhow::Result<ReleaseInfo> {
+        let mut response = ureq::get(&self.latest_release_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "composer-self-update")
+            .call()
+            .context("Failed to contact GitHub for the latest release")?;
+        let body = response
+            .body_mut()
+            .read_to_string()
+            .context("Failed to read the GitHub release response")?;
+        let json: serde_json::Value =
+            serde_json::from_str(&body).context("Failed to parse the GitHub release response")?;
+        let version = json
+            .get("tag_name")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow!("GitHub release response has no tag_name"))?
+            .to_string();
+        let assets = json
+            .get("assets")
+            .and_then(|value| value.as_array())
+            .map(|assets| {
+                assets
+                    .iter()
+                    .filter_map(|asset| {
+                        Some(ReleaseAsset {
+                            name: asset.get("name")?.as_str()?.to_string(),
+                            download_url: asset.get("browser_download_url")?.as_str()?.to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(ReleaseInfo { version, assets })
+    }
+
+    fn download(&self, url: &str, dest: &Path) -> anyhow::Result<()> {
+        let response = ureq::get(url)
+            .header("User-Agent", "composer-self-update")
+            .call()
+            .with_context(|| format!("Failed to download {}", url))?;
+        let mut reader = response.into_body().into_reader();
+        let mut file = File::create(dest)
+            .with_context(|| format!("Failed to create staging file '{}'", dest.display()))?;
+        io::copy(&mut reader, &mut file)
+            .context("Failed to write the downloaded binary to disk")?;
+        Ok(())
+    }
+}
+
+/// Real installer that swaps the running executable in place.
+pub struct SelfReplaceInstaller;
+
+impl BinaryInstaller for SelfReplaceInstaller {
+    fn install(&self, staged: &Path) -> anyhow::Result<()> {
+        make_executable(staged)?;
+        self_replace::self_replace(staged)
+            .context("Failed to replace the running composer executable")?;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(path)
+        .with_context(|| format!("Failed to read staging file '{}'", path.display()))?
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("Failed to mark '{}' as executable", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn gnu_asset(version: &str) -> ReleaseAsset {
+        ReleaseAsset {
+            name: format!("composer-{}-ubuntu-latest-x86_64-unknown-linux-gnu", version),
+            download_url: format!("https://example.com/{}/gnu", version),
+        }
+    }
+
+    fn full_asset_list(version: &str) -> Vec<ReleaseAsset> {
+        // Mirrors the asset names of a real release
+        let names = [
+            format!("composer-{}-1.x86_64.rpm", version),
+            format!("composer_{}-1_amd64.deb", version),
+            format!("composer-{}-macos-latest-x86_64-apple-darwin", version),
+            format!("composer-{}-ubuntu-latest-x86_64-unknown-linux-gnu", version),
+            format!("composer-{}-ubuntu-latest-x86_64-unknown-linux-musl", version),
+            format!("composer-{}-windows-latest-x86_64-pc-windows-msvc.exe", version),
+        ];
+        names
+            .iter()
+            .map(|name| ReleaseAsset {
+                name: name.clone(),
+                download_url: format!("https://example.com/{}", name),
+            })
+            .collect()
+    }
+
+    fn staging_path() -> PathBuf {
+        PathBuf::from("/tmp/composer-staging-test")
+    }
+
+    #[test]
+    fn up_to_date_release_skips_download_and_install() -> anyhow::Result<()> {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.5.3".to_string(),
+                assets: vec![gnu_asset("3.5.3")],
+            })
+        });
+        // No expectations on the installer: any call would fail the test
+        let installer = MockBinaryInstaller::new();
+
+        let outcome = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )?;
+        assert_eq!(
+            outcome,
+            SelfUpdateOutcome::UpToDate {
+                current: "3.5.3".to_string()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn older_remote_release_is_treated_as_up_to_date() -> anyhow::Result<()> {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.5.2".to_string(),
+                assets: vec![gnu_asset("3.5.2")],
+            })
+        });
+        let installer = MockBinaryInstaller::new();
+
+        let outcome = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )?;
+        assert_eq!(
+            outcome,
+            SelfUpdateOutcome::UpToDate {
+                current: "3.5.3".to_string()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn newer_release_downloads_matching_asset_and_installs() -> anyhow::Result<()> {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.6.0".to_string(),
+                assets: full_asset_list("3.6.0"),
+            })
+        });
+        api.expect_download()
+            .withf(|url, dest| {
+                url == "https://example.com/composer-3.6.0-ubuntu-latest-x86_64-unknown-linux-gnu"
+                    && dest == staging_path()
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let mut installer = MockBinaryInstaller::new();
+        installer
+            .expect_install()
+            .withf(|staged| staged == staging_path())
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let outcome = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )?;
+        assert_eq!(
+            outcome,
+            SelfUpdateOutcome::Updated {
+                from: "3.5.3".to_string(),
+                to: "3.6.0".to_string()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn check_only_reports_available_update_without_installing() -> anyhow::Result<()> {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.6.0".to_string(),
+                assets: full_asset_list("3.6.0"),
+            })
+        });
+        // No download or install expectations: any call would fail the test
+        let installer = MockBinaryInstaller::new();
+
+        let outcome = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            true,
+        )?;
+        assert_eq!(
+            outcome,
+            SelfUpdateOutcome::UpdateAvailable {
+                current: "3.5.3".to_string(),
+                latest: "3.6.0".to_string()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fetch_error_propagates_with_context() {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release()
+            .times(1)
+            .returning(|| Err(anyhow!("network down")));
+        let installer = MockBinaryInstaller::new();
+
+        let err = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{:#}", err).contains("Failed to fetch the latest release"),
+            "Should add fetch context: {:#}",
+            err
+        );
+    }
+
+    #[test]
+    fn download_error_propagates_and_skips_install() {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.6.0".to_string(),
+                assets: full_asset_list("3.6.0"),
+            })
+        });
+        api.expect_download()
+            .times(1)
+            .returning(|_, _| Err(anyhow!("connection reset")));
+        // Install must not be attempted after a failed download
+        let installer = MockBinaryInstaller::new();
+
+        let err = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{:#}", err).contains("Failed to download"),
+            "Should add download context: {:#}",
+            err
+        );
+    }
+
+    #[test]
+    fn missing_platform_asset_names_the_target() {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "3.6.0".to_string(),
+                assets: vec![ReleaseAsset {
+                    name: "composer-3.6.0-windows-latest-x86_64-pc-windows-msvc.exe".to_string(),
+                    download_url: "https://example.com/windows".to_string(),
+                }],
+            })
+        });
+        let installer = MockBinaryInstaller::new();
+
+        let err = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("x86_64-unknown-linux-gnu"),
+            "Should name the missing target: {}",
+            message
+        );
+    }
+
+    #[test]
+    fn unparseable_release_version_errors() {
+        let mut api = MockReleaseApi::new();
+        api.expect_latest_release().times(1).returning(|| {
+            Ok(ReleaseInfo {
+                version: "latest".to_string(),
+                assets: vec![],
+            })
+        });
+        let installer = MockBinaryInstaller::new();
+
+        let err = run_self_update(
+            &api,
+            &installer,
+            "3.5.3",
+            "x86_64-unknown-linux-gnu",
+            &staging_path(),
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("latest"),
+            "Should quote the bad version: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_parse_version() {
+        assert_eq!(parse_version("3.5.3"), Some((3, 5, 3)));
+        assert_eq!(parse_version("v3.5.3"), Some((3, 5, 3)));
+        assert_eq!(parse_version("0.0.0"), Some((0, 0, 0)));
+        assert_eq!(parse_version("3.5"), None);
+        assert_eq!(parse_version("3.5.3.1"), None);
+        assert_eq!(parse_version("latest"), None);
+        assert_eq!(parse_version("3.5.x"), None);
+    }
+
+    #[test]
+    fn test_select_asset_per_target() {
+        let assets = full_asset_list("3.6.0");
+        let gnu = select_asset(&assets, "x86_64-unknown-linux-gnu").expect("gnu asset");
+        assert!(gnu.name.ends_with("x86_64-unknown-linux-gnu"));
+        let musl = select_asset(&assets, "x86_64-unknown-linux-musl").expect("musl asset");
+        assert!(musl.name.ends_with("x86_64-unknown-linux-musl"));
+        let windows = select_asset(&assets, "x86_64-pc-windows-msvc").expect("windows asset");
+        assert!(windows.name.ends_with(".exe"));
+        let mac = select_asset(&assets, "x86_64-apple-darwin").expect("mac asset");
+        assert!(mac.name.contains("apple-darwin"));
+        assert_eq!(select_asset(&assets, "aarch64-unknown-linux-gnu"), None);
+    }
+
+    #[test]
+    fn test_select_asset_skips_packaged_artefacts() {
+        let assets = vec![ReleaseAsset {
+            name: "composer-x86_64-unknown-linux-gnu.rpm".to_string(),
+            download_url: "https://example.com/rpm".to_string(),
+        }];
+        assert_eq!(select_asset(&assets, "x86_64-unknown-linux-gnu"), None);
+    }
+}


### PR DESCRIPTION
Closes #11

## Change
New `composer self-update` subcommand:
- Fetches the latest release from the GitHub API, compares it against the compiled-in version, and if newer, downloads the asset matching the running platform (gnu vs musl detected via `target_env`, plus macOS and Windows) and swaps the running executable in place.
- `--check` reports whether a newer release exists without installing anything.
- Older or equal remote versions are treated as up to date (no downgrades); the RPM/deb assets are never selected.

## Design
Network and filesystem effects are behind traits per the testing rules: `ReleaseApi` (fetch metadata, download asset) and `BinaryInstaller` (swap the executable). `run_self_update` is pure orchestration over `&dyn` injections. Real implementations use `ureq` (rustls, so musl static builds stay self-contained) and the `self-replace` crate, which handles the Windows can't-delete-running-exe rename dance. Downloads stage into a tempdir; the staged file is chmod 755 on unix before the swap.

## Tests
Eleven new unit tests with mockall: up to date skips download/install, older remote treated as up to date, newer release downloads the right asset URL and installs it, `--check` installs nothing, fetch/download errors propagate with context (and a failed download never reaches install), missing platform asset names the target triple, unparseable tag errors, plus table tests for version parsing and asset selection against the real release asset naming. Full suite: 138 passed, clippy clean.

## Verification against the real API
Run from a dev build (version 0.0.0):
```
$ composer self-update --check
A newer composer release is available: 3.5.3 (currently 0.0.0). Run 'composer self-update' to install it.
```
The actual binary-replacement step was not exercised locally (sandbox policy blocks downloading and executing a release binary); it is covered by the mocked unit tests and worth a manual smoke test after the next release: install an old release, run `composer self-update`, then `composer --version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)