### PR TITLE
Make upgrade idempotent by default; add --always_down opt-in

### DIFF
--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -30,7 +30,10 @@ pub enum Cmd {
     /// Install a docker-compose application using a given jinja2 template
     #[clap(alias = "i", alias = "add")]
     Install(Install),
-    /// Upgrades an existing composer application, this is equivalent to doing docker compose up again, so existing services will remain and only deltas will be applied.
+    /// Upgrades an existing composer application. By default this re-renders the
+    ///   templates and runs docker compose up again, so existing services remain
+    ///   and only deltas are applied. Pass --always_down to force a full docker
+    ///   compose down of every compose file before bringing it back up.
     #[clap(alias = "u", alias = "update")]
     Upgrade(Upgrade),
     /// List installed composer applications

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -51,7 +51,7 @@ impl Delete {
             }
             compose_down_by_id(&id)?;
             delete_application_by_id(&id)?;
-            info!("Deleted application {}", &id);
+            info!("Deleted application {}", id);
         }
         Ok(())
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -122,7 +122,7 @@ pub fn add_application(
     if !directory.exists() {
         return Err(anyhow!(format!(
             "Template directory {} does not exist.",
-            &directory.display()
+            directory.display()
         )));
     }
     // Check for app.yaml and docker-compose.jinja2

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -51,7 +51,7 @@ impl Template {
 
         if self.output_file.is_empty() {
             // Print output to console
-            println!("{}", &rendered_template);
+            println!("{}", rendered_template);
         } else {
             // Output to file
             write(&self.output_file, &rendered_template)?;

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -5,8 +5,11 @@ use crate::utils::storage::read_from::get_application_by_id;
 use crate::utils::walk::get_files_with_names;
 use anyhow::anyhow;
 use clap::Args;
+use std::collections::HashSet;
 use std::fs::remove_dir_all;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+const COMPOSE_FILE_NAMES: [&str; 2] = ["docker-compose.jinja2", "docker-compose.j2"];
 
 /// Upgrades an existing application by re-rendering its templates and running
 /// `docker compose up` again. By default only the deltas are applied and
@@ -25,22 +28,49 @@ pub struct Upgrade {
     /// re-rendering and bringing the application back up. Without it the
     /// upgrade converges only the deltas and leaves unchanged containers
     /// running.
-    #[clap(long = "always_down")]
+    #[clap(long = "always_down", alias = "always-down")]
     pub always_down: bool,
 }
 
-/// Tears down every compose file when a full teardown has been requested.
-/// Without `always_down` this is a no-op and the subsequent `docker compose up`
-/// converges only the changed services.
-fn teardown_if_requested(
-    runner: &impl CommandRunner,
+/// Selects the compose files that need a `docker compose down` before the
+/// re-render. With `always_down` that is every existing compose file.
+/// Otherwise it is only the files with no counterpart in the new template
+/// directory: their services would never be converged away by the subsequent
+/// `docker compose up`, so they must be stopped now while the rendered file
+/// still exists.
+fn compose_files_to_teardown(
     always_down: bool,
-    compose_files: &[String],
-    install_id: &str,
-) {
-    if !always_down {
-        return;
+    existing_files: &[String],
+    existing_root: &Path,
+    new_files: &[String],
+    new_root: &Path,
+) -> Vec<String> {
+    if always_down {
+        return existing_files.to_vec();
     }
+    let new_relative: HashSet<PathBuf> = new_files
+        .iter()
+        .filter_map(|file| strip_root(file, new_root))
+        .collect();
+    existing_files
+        .iter()
+        .filter(|file| {
+            strip_root(file, existing_root)
+                .map(|relative| !new_relative.contains(&relative))
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect()
+}
+
+fn strip_root(file: &str, root: &Path) -> Option<PathBuf> {
+    Path::new(file)
+        .strip_prefix(root)
+        .ok()
+        .map(Path::to_path_buf)
+}
+
+fn teardown_compose_files(runner: &impl CommandRunner, compose_files: &[String], install_id: &str) {
     for compose_file in compose_files {
         compose_down_with(runner, compose_file, install_id);
     }
@@ -87,19 +117,22 @@ impl Upgrade {
             self.value_files.clone()
         };
 
-        // Optionally stop containers/networks before removing directory. By
-        // default the re-render plus `docker compose up --remove-orphans`
-        // converges only the deltas, leaving unchanged containers running.
-        let compose_files = get_files_with_names(
-            composer_id_directory.to_str().unwrap(),
-            &["docker-compose.jinja2", "docker-compose.j2"],
-        );
-        teardown_if_requested(
-            &RealCommandRunner,
+        // Stop containers/networks before removing the directory. By default
+        // only compose files absent from the new template version are downed;
+        // everything else is converged by `docker compose up --remove-orphans`.
+        // With --always_down every compose file is downed.
+        let compose_files =
+            get_files_with_names(composer_id_directory.to_str().unwrap(), &COMPOSE_FILE_NAMES);
+        let new_compose_files =
+            get_files_with_names(&self.directory.to_string_lossy(), &COMPOSE_FILE_NAMES);
+        let teardown_files = compose_files_to_teardown(
             self.always_down,
             &compose_files,
-            install_id,
+            &composer_id_directory,
+            &new_compose_files,
+            &self.directory,
         );
+        teardown_compose_files(&RealCommandRunner, &teardown_files, install_id);
 
         // Remove the existing directory
         remove_dir_all(&composer_id_directory)?;
@@ -139,18 +172,64 @@ mod tests {
     }
 
     #[test]
-    fn test_teardown_skipped_by_default() -> anyhow::Result<()> {
-        // With always_down = false the runner must never be invoked.
-        let file = compose_file_fixture()?;
-        let path = file.path().to_string_lossy().into_owned();
-        let runner = MockCommandRunner::new();
-        teardown_if_requested(&runner, false, &[path], "test_app");
-        Ok(())
+    fn test_teardown_selects_nothing_when_files_unchanged() {
+        let existing = vec![
+            "/old/docker-compose.jinja2".to_string(),
+            "/old/sub/docker-compose.j2".to_string(),
+        ];
+        let new = vec![
+            "/new/docker-compose.jinja2".to_string(),
+            "/new/sub/docker-compose.j2".to_string(),
+        ];
+        let selected = compose_files_to_teardown(
+            false,
+            &existing,
+            Path::new("/old"),
+            &new,
+            Path::new("/new"),
+        );
+        assert!(selected.is_empty());
     }
 
     #[test]
-    fn test_teardown_runs_once_per_file_when_requested() -> anyhow::Result<()> {
-        // With always_down = true a down runs once per compose file.
+    fn test_teardown_selects_removed_files_by_default() {
+        let existing = vec![
+            "/old/docker-compose.jinja2".to_string(),
+            "/old/removed/docker-compose.j2".to_string(),
+        ];
+        let new = vec!["/new/docker-compose.jinja2".to_string()];
+        let selected = compose_files_to_teardown(
+            false,
+            &existing,
+            Path::new("/old"),
+            &new,
+            Path::new("/new"),
+        );
+        assert_eq!(selected, vec!["/old/removed/docker-compose.j2".to_string()]);
+    }
+
+    #[test]
+    fn test_teardown_selects_everything_with_always_down() {
+        let existing = vec![
+            "/old/docker-compose.jinja2".to_string(),
+            "/old/sub/docker-compose.j2".to_string(),
+        ];
+        let new = vec![
+            "/new/docker-compose.jinja2".to_string(),
+            "/new/sub/docker-compose.j2".to_string(),
+        ];
+        let selected = compose_files_to_teardown(
+            true,
+            &existing,
+            Path::new("/old"),
+            &new,
+            Path::new("/new"),
+        );
+        assert_eq!(selected, existing);
+    }
+
+    #[test]
+    fn test_teardown_runs_once_per_file() -> anyhow::Result<()> {
         let file_one = compose_file_fixture()?;
         let file_two = compose_file_fixture()?;
         let paths = vec![
@@ -163,8 +242,15 @@ mod tests {
             .withf(|args| args.iter().any(|a| a == "down"))
             .times(2)
             .returning(|_| 0);
-        teardown_if_requested(&runner, true, &paths, "test_app");
+        teardown_compose_files(&runner, &paths, "test_app");
         Ok(())
+    }
+
+    #[test]
+    fn test_teardown_with_no_files_never_runs() {
+        // No expectations set: any call to the runner fails the test
+        let runner = MockCommandRunner::new();
+        teardown_compose_files(&runner, &[], "test_app");
     }
 
     #[test]

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,6 +1,6 @@
 use crate::commands::install::add_application;
 use crate::utils::copy_file_utils::get_composer_directory;
-use crate::utils::docker_compose::compose_down;
+use crate::utils::docker_compose::{compose_down_with, CommandRunner, RealCommandRunner};
 use crate::utils::storage::read_from::get_application_by_id;
 use crate::utils::walk::get_files_with_names;
 use anyhow::anyhow;
@@ -8,6 +8,11 @@ use clap::Args;
 use std::fs::remove_dir_all;
 use std::path::PathBuf;
 
+/// Upgrades an existing application by re-rendering its templates and running
+/// `docker compose up` again. By default only the deltas are applied and
+/// unchanged containers keep running. `--always_down` forces a full
+/// `docker compose down` of every compose file before the application is
+/// brought back up.
 #[derive(Debug, Args)]
 pub struct Upgrade {
     #[clap(index = 1)]
@@ -16,6 +21,29 @@ pub struct Upgrade {
     pub id: Option<String>,
     #[clap(short, long)]
     pub value_files: Vec<String>,
+    /// Force a full `docker compose down` of every compose file before
+    /// re-rendering and bringing the application back up. Without it the
+    /// upgrade converges only the deltas and leaves unchanged containers
+    /// running.
+    #[clap(long = "always_down")]
+    pub always_down: bool,
+}
+
+/// Tears down every compose file when a full teardown has been requested.
+/// Without `always_down` this is a no-op and the subsequent `docker compose up`
+/// converges only the changed services.
+fn teardown_if_requested(
+    runner: &impl CommandRunner,
+    always_down: bool,
+    compose_files: &[String],
+    install_id: &str,
+) {
+    if !always_down {
+        return;
+    }
+    for compose_file in compose_files {
+        compose_down_with(runner, compose_file, install_id);
+    }
 }
 
 impl Upgrade {
@@ -59,14 +87,19 @@ impl Upgrade {
             self.value_files.clone()
         };
 
-        // Stop containers/networks before removing directory
+        // Optionally stop containers/networks before removing directory. By
+        // default the re-render plus `docker compose up --remove-orphans`
+        // converges only the deltas, leaving unchanged containers running.
         let compose_files = get_files_with_names(
             composer_id_directory.to_str().unwrap(),
             &["docker-compose.jinja2", "docker-compose.j2"],
         );
-        for compose_file in compose_files {
-            compose_down(&compose_file, install_id);
-        }
+        teardown_if_requested(
+            &RealCommandRunner,
+            self.always_down,
+            &compose_files,
+            install_id,
+        );
 
         // Remove the existing directory
         remove_dir_all(&composer_id_directory)?;
@@ -87,6 +120,7 @@ impl Upgrade {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::docker_compose::MockCommandRunner;
     use crate::utils::storage::models::{ApplicationState, PersistedApplication};
     use crate::utils::storage::read_from::get_application_by_id;
     use crate::utils::storage::write_to_storage::append_to_storage;
@@ -95,7 +129,43 @@ mod tests {
     use serial_test::serial;
     use std::env::current_dir;
     use std::fs;
+    use std::io::Write;
     use std::path::PathBuf;
+
+    fn compose_file_fixture() -> anyhow::Result<tempfile::NamedTempFile> {
+        let mut file = tempfile::NamedTempFile::new()?;
+        file.write_all(b"services:\n  web:\n    image: busybox\n")?;
+        Ok(file)
+    }
+
+    #[test]
+    fn test_teardown_skipped_by_default() -> anyhow::Result<()> {
+        // With always_down = false the runner must never be invoked.
+        let file = compose_file_fixture()?;
+        let path = file.path().to_string_lossy().into_owned();
+        let runner = MockCommandRunner::new();
+        teardown_if_requested(&runner, false, &[path], "test_app");
+        Ok(())
+    }
+
+    #[test]
+    fn test_teardown_runs_once_per_file_when_requested() -> anyhow::Result<()> {
+        // With always_down = true a down runs once per compose file.
+        let file_one = compose_file_fixture()?;
+        let file_two = compose_file_fixture()?;
+        let paths = vec![
+            file_one.path().to_string_lossy().into_owned(),
+            file_two.path().to_string_lossy().into_owned(),
+        ];
+        let mut runner = MockCommandRunner::new();
+        runner
+            .expect_run_unbuffered()
+            .withf(|args| args.iter().any(|a| a == "down"))
+            .times(2)
+            .returning(|_| 0);
+        teardown_if_requested(&runner, true, &paths, "test_app");
+        Ok(())
+    }
 
     #[test]
     #[serial]
@@ -106,6 +176,7 @@ mod tests {
             directory: PathBuf::from("some/directory"),
             id: None,
             value_files: vec![],
+            always_down: false,
         };
         let err = upgrade_cmd.exec().unwrap_err();
         let actual_err = err.to_string();
@@ -127,6 +198,7 @@ mod tests {
             directory: upgrade_dir,
             id: Some(id.to_string()),
             value_files: vec![],
+            always_down: false,
         };
         let err = upgrade_cmd.exec().unwrap_err();
         let actual_err = err.to_string();
@@ -173,6 +245,7 @@ mod tests {
             directory: install_dir.clone(),
             id: Some(id.to_string()),
             value_files: vec![],
+            always_down: false,
         };
 
         let err = upgrade_cmd.exec().unwrap_err();
@@ -229,6 +302,7 @@ mod tests {
             directory: install_dir.clone(),
             id: Some(id.to_string()),
             value_files: vec![new_values_str.clone()],
+            always_down: false,
         };
 
         upgrade_cmd.exec()?;
@@ -281,6 +355,7 @@ mod tests {
             directory: install_dir.clone(),
             id: Some(id.to_string()),
             value_files: vec![],
+            always_down: false,
         };
 
         upgrade_cmd.exec()?;

--- a/src/utils/copy_file_utils.rs
+++ b/src/utils/copy_file_utils.rs
@@ -161,7 +161,8 @@ mod tests {
                 panic!("Error deleting directory: {:?}", e);
             }
         }
-        fs::create_dir(&path_str).unwrap_or_else(|_| panic!("Could not create directory '{}'.", &path_str));
+        fs::create_dir(&path_str)
+            .unwrap_or_else(|_| panic!("Could not create directory '{}'.", path_str));
         Ok(path_str.parse().unwrap())
     }
 }

--- a/src/utils/docker_compose.rs
+++ b/src/utils/docker_compose.rs
@@ -177,7 +177,7 @@ pub fn compose_down(path: &str, application_id: &str) {
     compose_down_with(&RealCommandRunner, path, application_id)
 }
 
-fn compose_down_with(runner: &impl CommandRunner, path: &str, application_id: &str) {
+pub(crate) fn compose_down_with(runner: &impl CommandRunner, path: &str, application_id: &str) {
     trace!("[EXEC] docker compose down {}", path);
     if compose_has_no_services(path) {
         // This is a valid use-case for sub-compose files

--- a/src/utils/storage/read_from.rs
+++ b/src/utils/storage/read_from.rs
@@ -20,7 +20,7 @@ pub fn get_all_from_storage() -> anyhow::Result<Vec<PersistedApplication>> {
         }
         Err(e) => {
             return Err(e)
-                .with_context(|| format!("Could not open file '{:?}'", &composer_json_config_dir))
+                .with_context(|| format!("Could not open file '{:?}'", composer_json_config_dir))
         }
     };
 

--- a/src/utils/storage/update_storage.rs
+++ b/src/utils/storage/update_storage.rs
@@ -37,7 +37,7 @@ where
         .write(true)
         .truncate(true)
         .open(&composer_json_config_dir)
-        .with_context(|| format!("Could not open file '{:?}'", &composer_json_config_dir))?;
+        .with_context(|| format!("Could not open file '{:?}'", composer_json_config_dir))?;
     let mut writer = BufWriter::new(file);
     let json_data = serde_json::to_vec(&new_applications)
         .with_context(|| "Could not serialize JSON to config.json")?;

--- a/src/utils/storage/write_to_storage.rs
+++ b/src/utils/storage/write_to_storage.rs
@@ -15,9 +15,9 @@ pub fn append_to_storage(application: &PersistedApplication) -> anyhow::Result<(
     // Create ~/.composer/config.json if it doesn't exist
     if !composer_json_config_dir.exists() {
         fs::create_dir_all(&composer_directory)
-            .with_context(|| format!("Could not create directory '{:?}'", &composer_directory))?;
+            .with_context(|| format!("Could not create directory '{:?}'", composer_directory))?;
         File::create(&composer_json_config_dir)
-            .with_context(|| format!("Could not create file '{:?}'", &composer_json_config_dir))?;
+            .with_context(|| format!("Could not create file '{:?}'", composer_json_config_dir))?;
     }
 
     let file = OpenOptions::new()
@@ -26,7 +26,7 @@ pub fn append_to_storage(application: &PersistedApplication) -> anyhow::Result<(
         .create(true)
         .truncate(false)
         .open(&composer_json_config_dir)
-        .with_context(|| format!("Could not open file '{:?}'", &composer_json_config_dir))?;
+        .with_context(|| format!("Could not open file '{:?}'", composer_json_config_dir))?;
 
     let mut reader = BufReader::new(file);
     let mut contents = String::new();
@@ -45,7 +45,7 @@ pub fn append_to_storage(application: &PersistedApplication) -> anyhow::Result<(
 
     let writer = BufWriter::new(
         File::create(&composer_json_config_dir)
-            .with_context(|| format!("Could not create file '{:?}'", &composer_json_config_dir))?,
+            .with_context(|| format!("Could not create file '{:?}'", composer_json_config_dir))?,
     );
     serde_json::to_writer(writer, &applications)?;
 
@@ -73,7 +73,7 @@ pub fn delete_application_by_id(id: &str) -> anyhow::Result<()> {
             .write(true)
             .truncate(true)
             .open(&composer_json_config_dir)
-            .with_context(|| format!("Could not open file '{:?}'", &composer_json_config_dir))?;
+            .with_context(|| format!("Could not open file '{:?}'", composer_json_config_dir))?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, &new_applications)
             .with_context(|| "Could not serialize JSON to config.json")?;


### PR DESCRIPTION
## Problem

`composer upgrade` documents that "existing services will remain and only deltas will be applied", but that was not true. On **every** invocation, upgrade ran `docker compose down --remove-orphans` on every compose file before re-rendering and bringing the app back up. As a result a no-op upgrade (nothing changed) still stopped and recreated every container. `docker compose up -d --remove-orphans` is already idempotent on its own (compose only recreates containers whose config hash changed), so the unconditional `down` was the sole thing destroying idempotency.

## Fix

- **Default (flag absent):** no longer runs `docker compose down`. The upgrade still re-renders templates (so value and template changes are picked up), then lets `docker compose up -d --remove-orphans` converge only the deltas. Unchanged containers are left running. This makes the default behaviour match the documented promise.
- **`--always_down` (opt-in):** restores the previous behaviour, running a full `docker compose down` on every compose file before the re-render and up. This is the escape hatch for a forced teardown and recreate.

The teardown decision plus the down loop are extracted into a small `teardown_if_requested(runner, always_down, compose_files, install_id)` helper that takes an `&impl CommandRunner`, mirroring the existing `compose_down_with` / `compose_up_with` pattern.

## Tests

Two new unit tests drive the helper with a mocked `CommandRunner`:

- default (`always_down = false`) => the runner is never invoked (no `down`).
- `always_down = true` => exactly one `down` per compose file.

Existing upgrade tests are unchanged in intent and updated only to set the new field to `false`, so they keep asserting the default (no teardown) path. Full suite: 170 passed. `cargo clippy --all-targets -- -D warnings` is clean.