### PR TITLE
fix: detect empty services mappings in compose files

### DIFF
--- a/src/utils/docker_compose.rs
+++ b/src/utils/docker_compose.rs
@@ -153,23 +153,27 @@ fn check_compose_is_valid(compose_path: &str) -> anyhow::Result<()> {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Compose {
-    services: Option<Vec<String>>,
+    // The compose spec defines services as a mapping; Value also tolerates
+    // the null and empty-sequence forms emitted by some templates.
+    services: Option<Value>,
 }
 
 fn compose_has_no_services(compose_path: &str) -> bool {
     let compose_content = match fs::read_to_string(compose_path) {
         Ok(content) => content,
-        Err(_) => return false, // Error reading file, return false
+        Err(_) => return false, // Unreadable file: conservatively assume it has services
     };
 
-    let compose: Result<Compose, serde_yaml::Error> = serde_yaml::from_str(&compose_content);
+    let compose: Compose = match serde_yaml::from_str(&compose_content) {
+        Ok(compose) => compose,
+        Err(_) => return false, // Unparsable YAML: conservatively assume it has services
+    };
 
-    match compose {
-        Ok(compose_obj) => match compose_obj.services {
-            Some(services) => services.is_empty(),
-            None => true,
-        },
-        Err(_) => false, // Error parsing YAML, return false
+    match compose.services {
+        None | Some(Value::Null) => true,
+        Some(Value::Mapping(services)) => services.is_empty(),
+        Some(Value::Sequence(services)) => services.is_empty(),
+        Some(_) => false,
     }
 }
 
@@ -313,6 +317,44 @@ mod tests {
         // No expectations set: any call to the runner fails the test
         let runner = MockCommandRunner::new();
         compose_up_with(&runner, &path_str(&file), "test_app")
+    }
+
+    #[test]
+    fn test_compose_up_skips_empty_services_mapping() -> anyhow::Result<()> {
+        let file = temp_compose_file("services: {}\n")?;
+        // No expectations set: any call to the runner fails the test
+        let runner = MockCommandRunner::new();
+        compose_up_with(&runner, &path_str(&file), "test_app")
+    }
+
+    #[test]
+    fn test_compose_down_skips_empty_services_mapping() -> anyhow::Result<()> {
+        let file = temp_compose_file("services: {}\n")?;
+        let runner = MockCommandRunner::new();
+        compose_down_with(&runner, &path_str(&file), "test_app");
+        Ok(())
+    }
+
+    #[test]
+    fn test_compose_has_no_services_matrix() -> anyhow::Result<()> {
+        let cases = [
+            (COMPOSE_WITH_SERVICES, false),
+            ("services: {}\n", true),
+            ("services:\n", true),
+            ("services: []\n", true),
+            ("networks: {}\n", true),
+            ("services: [unclosed\n", false),
+        ];
+        for (content, expected) in cases {
+            let file = temp_compose_file(content)?;
+            assert_eq!(
+                expected,
+                compose_has_no_services(&path_str(&file)),
+                "content: {:?}",
+                content
+            );
+        }
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`compose_has_no_services` in `src/utils/docker_compose.rs` modelled the compose file as `services: Option<Vec<String>>`. In the compose spec `services` is a mapping, so parsing any normal compose file into a `Vec` failed and fell through the `Err` arm, which returns "has services". Normal files therefore only behaved correctly by accident, and `services: {}` (the natural render of a template with zero services) was treated as having services. `docker compose up` then ran against it, errored, marked the whole application as `Error` and exited the process. Only `services:` (null) and `services: []` triggered the intended skip.

## Fix

Deserialise `services` as `Option<serde_yaml::Value>` and treat it as "no services" when it is missing, null, an empty mapping, or an empty sequence. A non-empty mapping or sequence counts as having services, so real compose files now take the successful-parse path rather than the parse-failure path. The conservative fallback is kept: an unreadable or unparsable file is still treated as having services. The predicate is shared by `compose_up_with` and `compose_down_with`, so both paths are fixed.

## Tests

- `test_compose_up_skips_empty_services_mapping`: `services: {}` must not invoke the command runner via `compose_up_with` (fails on master, where the mock is called with `docker compose up`)
- `test_compose_down_skips_empty_services_mapping`: same for `compose_down_with` (fails on master)
- `test_compose_has_no_services_matrix`: direct coverage of the predicate across a normal mapping, `services: {}`, `services:` null, `services: []`, a missing services key, and invalid YAML (fails on master on the `services: {}` case)
- Existing tests all pass, including `COMPOSE_WITH_SERVICES` cases which now exercise a successful parse

Full suite passes (`cargo test --locked`, 176 tests) and `cargo clippy --all-targets --locked -- -D warnings` is clean.

Fixes #47