### PR TITLE
fix: return an error from compose up instead of exiting the process

### DIFF
--- a/src/utils/docker_compose.rs
+++ b/src/utils/docker_compose.rs
@@ -113,8 +113,11 @@ fn compose_up_with(
                 application_id, e
             );
         }
-        error!("docker compose up has failed for app {}", application_id);
-        std::process::exit(exit_code);
+        return Err(anyhow::anyhow!(
+            "docker compose up failed for app {} with exit code {}",
+            application_id,
+            exit_code
+        ));
     }
     Ok(())
 }
@@ -238,6 +241,11 @@ fn compose_pull_with(runner: &impl CommandRunner, path: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::storage::models::PersistedApplication;
+    use crate::utils::storage::read_from::get_application_by_id;
+    use crate::utils::storage::write_to_storage::append_to_storage;
+    use crate::utils::test_utils::ComposerHomeGuard;
+    use serial_test::serial;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -305,6 +313,51 @@ mod tests {
             .times(1)
             .returning(|_| 0);
         compose_up_with(&runner, &path, "test_app")
+    }
+
+    #[test]
+    #[serial]
+    fn test_compose_up_failure_returns_error_naming_app() -> anyhow::Result<()> {
+        let _home = ComposerHomeGuard::new()?;
+        let file = temp_compose_file(COMPOSE_WITH_SERVICES)?;
+        let mut runner = MockCommandRunner::new();
+        runner.expect_run_unbuffered().times(1).returning(|_| 17);
+        let err = compose_up_with(&runner, &path_str(&file), "failing_app").unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("failing_app"),
+            "error should name the app: {}",
+            message
+        );
+        assert!(
+            message.contains("17"),
+            "error should include the exit code: {}",
+            message
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_compose_up_failure_marks_application_as_error() -> anyhow::Result<()> {
+        let _home = ComposerHomeGuard::new()?;
+        let id = "compose_up_failure_state";
+        append_to_storage(&PersistedApplication {
+            id: id.to_string(),
+            version: "1".to_string(),
+            timestamp: 0,
+            state: ApplicationState::Starting,
+            app_name: id.to_string(),
+            compose_path: id.to_string(),
+            value_files: vec![],
+        })?;
+        let file = temp_compose_file(COMPOSE_WITH_SERVICES)?;
+        let mut runner = MockCommandRunner::new();
+        runner.expect_run_unbuffered().times(1).returning(|_| 1);
+        let result = compose_up_with(&runner, &path_str(&file), id);
+        assert!(result.is_err());
+        assert_eq!(ApplicationState::Error, get_application_by_id(id)?.state);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`compose_up_with` handled a non-zero `docker compose up` exit code by marking the application as `Error` and then calling `std::process::exit(exit_code)` from deep inside library code. That meant `add_application` could never finish or clean up, remaining compose files were never processed, the post-command update notice in `main` was skipped, callers that treat `compose_up` as fallible never saw the error, and the failure path was untestable because the test process would exit. `compose_down_with` logs and carries on, so the two siblings behaved inconsistently.

## Fix

After setting the application state to `Error` (unchanged), `compose_up_with` now returns an `anyhow::Error` naming the application id and the compose exit code instead of exiting the process. The redundant `error!` log was removed since `main` already prints the full error chain via `error!("{:#}", e)` and exits 1, so keeping it would double-report. The only caller, `add_application`, already propagates `compose_up` errors with `?`, so no caller changes were needed.

## Behaviour change

The process exit code for a failed `docker compose up` is now 1 (main's generic error path) rather than the compose exit code that was previously passed straight to `std::process::exit`.

## Tests

- `test_compose_up_failure_returns_error_naming_app`: the mock runner returns exit code 17 and the test asserts `compose_up_with` returns `Err` with the app id and exit code in the message. On master this test cannot even be written: the function would call `std::process::exit(17)` and kill the test process.
- `test_compose_up_failure_marks_application_as_error`: with `COMPOSER_HOME` pointed at a temporary directory and a `PersistedApplication` appended via `append_to_storage`, asserts the application state is `Error` after the failed up. Both new tests are `#[serial]` because they use the process-wide `COMPOSER_HOME` override.
- The existing happy-path test (`test_compose_up_runs_command_for_valid_file`) still passes, covering the `Ok` path.

Full suite (`cargo test --locked`) passes and `cargo clippy --all-targets --locked -- -D warnings` is clean.

Fixes #48