### PR TITLE
fix: tear down docker-compose.j2 files on delete

### DIFF
--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,11 +1,13 @@
 use crate::utils::copy_file_utils::get_composer_directory;
-use crate::utils::docker_compose::compose_down;
+use crate::utils::docker_compose::{
+    compose_down_with, CommandRunner, RealCommandRunner, COMPOSE_FILE_NAMES,
+};
 use crate::utils::storage::read_from::{get_all_from_storage, if_application_exists};
 use crate::utils::storage::write_to_storage::delete_application_by_id;
-use crate::utils::walk::get_files_with_name;
+use crate::utils::walk::get_files_with_names;
 use anyhow::anyhow;
 use clap::Args;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Args)]
 pub struct Delete {
@@ -17,20 +19,21 @@ pub struct Delete {
     pub all: bool,
 }
 
-// Call docker compose down on all docker-compose.jinja2 files for this application
-fn compose_down_by_id(id: &str) -> anyhow::Result<()> {
+// Call docker compose down on all compose files for this application
+fn compose_down_by_id(runner: &impl CommandRunner, id: &str) -> anyhow::Result<()> {
     // Ensure the .composer directory exists
     let composer_directory = get_composer_directory()?;
     let composer_id_directory: PathBuf = composer_directory.join(id);
-    // Find all docker-compose.jinja2 files
-    let all_compose_files = get_files_with_name(
-        composer_id_directory.to_str().unwrap(),
-        "docker-compose.jinja2",
-    );
-    for compose_file in all_compose_files {
-        compose_down(&compose_file, id);
-    }
+    compose_down_in_directory(runner, &composer_id_directory, id);
     Ok(())
+}
+
+// Run docker compose down on every compose file found under the directory
+fn compose_down_in_directory(runner: &impl CommandRunner, directory: &Path, id: &str) {
+    let all_compose_files = get_files_with_names(&directory.to_string_lossy(), &COMPOSE_FILE_NAMES);
+    for compose_file in all_compose_files {
+        compose_down_with(runner, &compose_file, id);
+    }
 }
 
 impl Delete {
@@ -38,7 +41,7 @@ impl Delete {
         // If the all flag is set, delete all applications
         if self.all {
             for app in get_all_from_storage()? {
-                compose_down_by_id(&app.id)?;
+                compose_down_by_id(&RealCommandRunner, &app.id)?;
                 delete_application_by_id(&app.id)?;
                 info!("Deleted application {}", app.id);
             }
@@ -49,10 +52,88 @@ impl Delete {
             if !if_application_exists(&id) {
                 return Err(anyhow!("Could not find application '{}' to delete it.", id));
             }
-            compose_down_by_id(&id)?;
+            compose_down_by_id(&RealCommandRunner, &id)?;
             delete_application_by_id(&id)?;
             info!("Deleted application {}", id);
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::docker_compose::MockCommandRunner;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const COMPOSE_WITH_SERVICES: &str = "services:\n  web:\n    image: busybox\n";
+
+    // Builds <temp>/<id>/<file> for each file name, mirroring the layout of a
+    // rendered application under the composer directory.
+    fn app_dir_with_compose_files(
+        id: &str,
+        file_names: &[&str],
+    ) -> anyhow::Result<(TempDir, PathBuf)> {
+        let composer_dir = TempDir::new()?;
+        let app_dir = composer_dir.path().join(id);
+        fs::create_dir_all(&app_dir)?;
+        for file_name in file_names {
+            fs::write(app_dir.join(file_name), COMPOSE_WITH_SERVICES)?;
+        }
+        Ok((composer_dir, app_dir))
+    }
+
+    fn expect_down_for_file(runner: &mut MockCommandRunner, compose_path: &Path) {
+        let expected_path = compose_path.to_string_lossy().into_owned();
+        runner
+            .expect_run_unbuffered()
+            .withf(move |args| {
+                args.iter().any(|arg| arg == "down") && args.iter().any(|arg| arg == &expected_path)
+            })
+            .times(1)
+            .returning(|_| 0);
+    }
+
+    #[test]
+    fn test_delete_downs_j2_compose_file() -> anyhow::Result<()> {
+        let id = "test_delete_j2";
+        let (_composer_dir, app_dir) = app_dir_with_compose_files(id, &["docker-compose.j2"])?;
+        let mut runner = MockCommandRunner::new();
+        expect_down_for_file(&mut runner, &app_dir.join("docker-compose.j2"));
+        compose_down_in_directory(&runner, &app_dir, id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_downs_jinja2_compose_file() -> anyhow::Result<()> {
+        let id = "test_delete_jinja2";
+        let (_composer_dir, app_dir) = app_dir_with_compose_files(id, &["docker-compose.jinja2"])?;
+        let mut runner = MockCommandRunner::new();
+        expect_down_for_file(&mut runner, &app_dir.join("docker-compose.jinja2"));
+        compose_down_in_directory(&runner, &app_dir, id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_downs_mixed_compose_files() -> anyhow::Result<()> {
+        let id = "test_delete_mixed";
+        let (_composer_dir, app_dir) =
+            app_dir_with_compose_files(id, &["docker-compose.jinja2", "docker-compose.j2"])?;
+        let mut runner = MockCommandRunner::new();
+        expect_down_for_file(&mut runner, &app_dir.join("docker-compose.jinja2"));
+        expect_down_for_file(&mut runner, &app_dir.join("docker-compose.j2"));
+        compose_down_in_directory(&runner, &app_dir, id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_with_no_compose_files_never_runs() -> anyhow::Result<()> {
+        let id = "test_delete_empty";
+        let (_composer_dir, app_dir) = app_dir_with_compose_files(id, &[])?;
+        // No expectations set: any call to the runner fails the test
+        let runner = MockCommandRunner::new();
+        compose_down_in_directory(&runner, &app_dir, id);
         Ok(())
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -4,7 +4,7 @@ use crate::utils::load_values::{get_value_files_as_refs, load_yaml_files};
 use crate::utils::walk::{get_files_with_extensions, get_files_with_names};
 use anyhow::anyhow;
 
-use crate::utils::docker_compose::{compose_pull, compose_up};
+use crate::utils::docker_compose::{compose_pull, compose_up, COMPOSE_FILE_NAMES};
 use crate::utils::storage::app_yaml::load_app_yaml;
 use crate::utils::storage::models::{ApplicationState, PersistedApplication};
 use crate::utils::storage::write_to_storage::append_to_storage;
@@ -175,10 +175,8 @@ pub fn add_application(
     let no_run = app::no_run();
 
     // Find all docker-compose template files
-    let all_compose_files = get_files_with_names(
-        composer_id_directory.to_str().unwrap(),
-        &["docker-compose.jinja2", "docker-compose.j2"],
-    );
+    let all_compose_files =
+        get_files_with_names(composer_id_directory.to_str().unwrap(), &COMPOSE_FILE_NAMES);
     for compose_file in all_compose_files {
         if *app::always_pull() {
             info!("Always pull is enabled. Pulling latest docker images.");

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,6 +1,8 @@
 use crate::commands::install::add_application;
 use crate::utils::copy_file_utils::get_composer_directory;
-use crate::utils::docker_compose::{compose_down_with, CommandRunner, RealCommandRunner};
+use crate::utils::docker_compose::{
+    compose_down_with, CommandRunner, RealCommandRunner, COMPOSE_FILE_NAMES,
+};
 use crate::utils::storage::read_from::get_application_by_id;
 use crate::utils::walk::get_files_with_names;
 use anyhow::anyhow;
@@ -8,8 +10,6 @@ use clap::Args;
 use std::collections::HashSet;
 use std::fs::remove_dir_all;
 use std::path::{Path, PathBuf};
-
-const COMPOSE_FILE_NAMES: [&str; 2] = ["docker-compose.jinja2", "docker-compose.j2"];
 
 /// Upgrades an existing application by re-rendering its templates and running
 /// `docker compose up` again. By default only the deltas are applied and

--- a/src/utils/docker_compose.rs
+++ b/src/utils/docker_compose.rs
@@ -7,6 +7,9 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+/// File names recognised as docker compose templates by install, upgrade and delete.
+pub(crate) const COMPOSE_FILE_NAMES: [&str; 2] = ["docker-compose.jinja2", "docker-compose.j2"];
+
 /// Abstraction over external process execution so command orchestration
 /// can be unit tested without spawning real processes.
 #[cfg_attr(test, mockall::automock)]
@@ -171,10 +174,6 @@ fn compose_has_no_services(compose_path: &str) -> bool {
         },
         Err(_) => false, // Error parsing YAML, return false
     }
-}
-
-pub fn compose_down(path: &str, application_id: &str) {
-    compose_down_with(&RealCommandRunner, path, application_id)
 }
 
 pub(crate) fn compose_down_with(runner: &impl CommandRunner, path: &str, application_id: &str) {

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::utils::copy_file_utils::get_composer_directory;
-use crate::utils::docker_compose::compose_down;
+use crate::utils::docker_compose::{compose_down_with, RealCommandRunner, COMPOSE_FILE_NAMES};
 use crate::utils::walk::get_files_with_names;
 use anyhow::anyhow;
 use std::fs;
@@ -81,12 +81,10 @@ pub fn clean_up_test_folder(id: &str) -> anyhow::Result<()> {
 
     // Stop Docker containers/networks BEFORE removing files
     if composer_id_directory.exists() {
-        let compose_files = get_files_with_names(
-            composer_id_directory.to_str().unwrap(),
-            &["docker-compose.jinja2", "docker-compose.j2"],
-        );
+        let compose_files =
+            get_files_with_names(composer_id_directory.to_str().unwrap(), &COMPOSE_FILE_NAMES);
         for compose_file in compose_files {
-            compose_down(&compose_file, id);
+            compose_down_with(&RealCommandRunner, &compose_file, id);
         }
         fs::remove_dir_all(composer_id_directory)?;
     }

--- a/src/utils/walk.rs
+++ b/src/utils/walk.rs
@@ -28,21 +28,6 @@ pub fn get_files_with_extensions(dir: &str, extensions: &[&str]) -> Vec<String> 
         .collect()
 }
 
-pub fn get_files_with_name(dir: &str, name: &str) -> Vec<String> {
-    WalkDir::new(dir)
-        .into_iter()
-        .filter_map(|entry| {
-            if let Ok(entry) = entry {
-                if entry.file_type().is_file()
-                    && entry.file_name().to_string_lossy() == name {
-                        return Some(entry.path().to_string_lossy().into_owned());
-                    }
-            }
-            None
-        })
-        .collect()
-}
-
 /// Recursively searches a directory for files with any of the specified file names.
 pub fn get_files_with_names(dir: &str, names: &[&str]) -> Vec<String> {
     WalkDir::new(dir)
@@ -63,7 +48,7 @@ pub fn get_files_with_names(dir: &str, names: &[&str]) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::walk::{get_files_with_extensions, get_files_with_name, get_files_with_names};
+    use crate::utils::walk::{get_files_with_extensions, get_files_with_names};
 
     use relative_path::RelativePath;
     use std::env::current_dir;
@@ -117,17 +102,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_files_with_name() -> anyhow::Result<()> {
-        let current_dir = current_dir()?;
-        let target_dir =
-            RelativePath::new("resources/test/walk_test").to_logical_path(&current_dir);
-        let actual = get_files_with_name(target_dir.to_str().unwrap(), "file1.jinja2");
-        let actual_relative = get_relative_files(actual, &current_dir);
-        assert_eq!(vec!["resources/test/walk_test/file1.jinja2"], actual_relative);
-        Ok(())
-    }
-
-    #[test]
     fn test_get_files_with_names_finds_nested_files() -> anyhow::Result<()> {
         let current_dir = current_dir()?;
         let target_dir =
@@ -147,8 +121,8 @@ mod tests {
     }
 
     #[test]
-    fn test_get_files_with_name_missing_dir_returns_empty() {
-        let actual = get_files_with_name("/nonexistent/composer-walk-test", "file1.jinja2");
+    fn test_get_files_with_names_missing_dir_returns_empty() {
+        let actual = get_files_with_names("/nonexistent/composer-walk-test", &["file1.jinja2"]);
         assert!(actual.is_empty());
     }
 


### PR DESCRIPTION
## Problem

`composer delete` only searched for `docker-compose.jinja2` files when running `docker compose down`, via `get_files_with_name` in `compose_down_by_id`. Install and upgrade recognise both supported template names (`docker-compose.jinja2` and `docker-compose.j2`), so deleting an application whose templates use the `.j2` name removed the storage entry and the rendered directory but never stopped the containers, leaving them running with nothing left to manage them. Same failure class as the upgrade teardown gap fixed in #43.

## Fix

- Centralised the recognised template names as `pub(crate) COMPOSE_FILE_NAMES` in `src/utils/docker_compose.rs` (moved from `upgrade.rs`) and reused it from `upgrade.rs`, `delete.rs`, `install.rs`'s `add_application` and the test clean-up helper, so the list cannot drift again.
- `compose_down_by_id` now finds compose files with `get_files_with_names` using that shared list, and delegates to a new `compose_down_in_directory` helper that takes a `CommandRunner`, mirroring the `teardown_compose_files` refactor from #43. `Delete::exec` passes `RealCommandRunner`.
- Removed `compose_down` and `get_files_with_name`, which had no remaining production callers after the change (the test clean-up helper now calls `compose_down_with` directly).

## Tests

New regression tests in `delete.rs` drive `compose_down_in_directory` with a `MockCommandRunner` against a temp directory laid out like a rendered application:

- `.j2` only: exactly one `down` invocation whose args include the `.j2` path (fails on master, where the file is never found and no `down` runs)
- `.jinja2` only: one `down` invocation
- mixed `.jinja2` + `.j2`: one `down` per file (also fails on master)
- no compose files: the runner is never invoked

Full suite passes with `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` is clean.

Fixes #45