### PR TITLE
fix: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -96,9 +96,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -120,9 +120,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -337,9 +337,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -562,9 +562,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -579,9 +579,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -621,9 +621,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
 dependencies = [
  "memo-map",
  "serde",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1185,18 +1185,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1223,9 +1223,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
  "base64",
  "flate2",
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
  "base64",
  "http",
@@ -1280,9 +1280,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ log = { version = "0.4.33", features = ["std"] }
 gitignore = "1.0.8"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10.0" }
-minijinja = "2.21.0"
-clap = { version = "4.6.5", features = ["derive"] }
+minijinja = "2.23.0"
+clap = { version = "4.6.6", features = ["derive"] }
 anyhow = "1.0.104"
 once_cell = "1.21.4"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
@@ -47,7 +47,7 @@ dirs = "6.0.0"
 serde_json = "1.0.151"
 chrono = "0.4.45"
 chrono-humanize = "0.2.3"
-ureq = "3.3.0"
+ureq = "3.4.0"
 self-replace = "1.5.0"
 tempfile = "3.27"
 

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -1,8 +1,22 @@
-use minijinja::{Environment, ErrorKind};
+use minijinja::value::ValueKind;
+use minijinja::{Environment, ErrorKind, Output, State};
 use serde_yaml::Value;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+
+/// Renders booleans as lowercase `true`/`false`; minijinja 2.22+ defaults to
+/// Python-style `True`/`False`, which would change existing rendered output.
+pub fn lowercase_bool_formatter(
+    out: &mut Output,
+    state: &State,
+    value: &minijinja::value::Value,
+) -> Result<(), minijinja::Error> {
+    if value.kind() == ValueKind::Bool {
+        return Ok(out.write_str(if value.is_true() { "true" } else { "false" })?);
+    }
+    minijinja::escape_formatter(out, state, value)
+}
 
 /// A custom filter for required
 /// Hello {{ world_variable | required }}
@@ -38,6 +52,7 @@ pub fn render_template(path: &str, values_yaml: Value) -> anyhow::Result<String>
 
     // Create a Jinja environment
     let mut env = Environment::new();
+    env.set_formatter(lowercase_bool_formatter);
 
     // Get the directory of the template file
     let template_dir = Path::new(path)

--- a/src/utils/value_resolver/mod.rs
+++ b/src/utils/value_resolver/mod.rs
@@ -29,6 +29,7 @@ impl Default for MiniJinjaRenderer {
 impl TemplateRenderer for MiniJinjaRenderer {
     fn render(&self, template_str: &str, context: &Value) -> Result<String> {
         let mut env = Environment::new();
+        env.set_formatter(crate::utils::template::lowercase_bool_formatter);
 
         env.add_template("inline", template_str)
             .with_context(|| format!("Failed to parse template: {}", template_str))?;
@@ -273,6 +274,21 @@ message: "{{ undefined_var | default('fallback') }}"
         assert_eq!(
             resolved.get("message").unwrap(),
             &Value::String("fallback".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boolean_reference_renders_lowercase() {
+        let yaml = r#"
+enabled: true
+flag: "{{ enabled }}"
+"#;
+        let values: Value = from_str(yaml).unwrap();
+        let resolved = resolve_value_references(values).unwrap();
+
+        assert_eq!(
+            resolved.get("flag").unwrap(),
+            &Value::String("true".to_string())
         );
     }
 


### PR DESCRIPTION
Automated weekly dependency update by dev-autopilot.

Everything is verified. The `/tmp/composer-vendor` directory I created for inspection couldn't be removed due to sandbox limits, but it's outside the repository and harmless.

## Summary
Weekly dependency update: three crates had new releases (minijinja, clap, ureq), all semver-compatible, plus a lockfile refresh of transitive dependencies. A behaviour change in minijinja's boolean rendering was neutralised with a custom formatter so template output is unchanged.

## Dependencies bumped
- minijinja: 2.21.0 -> 2.23.0
- clap: 4.6.5 -> 4.6.6
- ureq: 3.3.0 -> 3.4.0
- Transitive updates via `cargo update` (aho-corasick, regex-automata, thiserror, cc, clap_complete, wasm-bindgen family, and others)

No major-version bumps this week; all other direct dependencies were already at their latest stable versions.

## Code changes
- `src/utils/template.rs`: minijinja 2.22+ renders booleans Python-style (`True`/`False` instead of `true`/`false`), which would have silently changed rendered compose files (for example `DEBUG={{ debug }}` becoming `DEBUG=True`). Added a `lowercase_bool_formatter` and set it on the rendering environment to keep the historical lowercase output.
- `src/utils/value_resolver/mod.rs`: applied the same formatter to the value-reference resolver's minijinja environment so booleans referenced from values files also keep rendering lowercase, and added a regression test covering it.

## Verification
`cargo build` (dev and release) succeeds, `cargo test` passes 203 tests (202 baseline plus the new boolean regression test) including the docker-backed install/upgrade tests, and `cargo clippy --all-targets -- -D warnings` reports no warnings.

<details><summary>Cargo.toml diff</summary>

```diff
diff --git a/Cargo.toml b/Cargo.toml
index 0c935c3..3a8f515 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ log = { version = "0.4.33", features = ["std"] }
 gitignore = "1.0.8"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10.0" }
-minijinja = "2.21.0"
-clap = { version = "4.6.5", features = ["derive"] }
+minijinja = "2.23.0"
+clap = { version = "4.6.6", features = ["derive"] }
 anyhow = "1.0.104"
 once_cell = "1.21.4"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
@@ -47,7 +47,7 @@ dirs = "6.0.0"
 serde_json = "1.0.151"
 chrono = "0.4.45"
 chrono-humanize = "0.2.3"
-ureq = "3.3.0"
+ureq = "3.4.0"
 self-replace = "1.5.0"
 tempfile = "3.27"
 
```

</details>

Please review the diff and CI before merging.
